### PR TITLE
Map fixes

### DIFF
--- a/content/pets.json
+++ b/content/pets.json
@@ -155,6 +155,7 @@
                 "Medium Sized Bank Coin",
                 "Rather Large Bank Coin",
                 "Weirdly Sized Bank Coin",
+                "Evil Bank Coin",
                 "Ashen Bank Coin"
             ],
             "achievements": [

--- a/world-maps/dungeons/cellar/Frigri Wine Cellar -2.json
+++ b/world-maps/dungeons/cellar/Frigri Wine Cellar -2.json
@@ -34,8 +34,9 @@
                  "name":"ToNorkos",
                  "properties":
                     {
-                     "destx":"116",
-                     "desty":"169",
+                     "customMessage":"%playerName does not remember how, but ends up on the streets of %destName.",
+                     "destx":"134",
+                     "desty":"160",
                      "map":"Norkos",
                      "movementType":"teleport"
                     },

--- a/world-maps/dungeons/homlet/Homlet Caves.json
+++ b/world-maps/dungeons/homlet/Homlet Caves.json
@@ -220,7 +220,7 @@
                  "properties":
                     {
                      "flavorText":"A crystal that appears to be preserving some chunks of dirt inside of it.",
-                     "storyline":"Lore: Earth Plains"
+                     "storyline":"Lore: Earth Plane"
                     },
                  "rotation":0,
                  "type":"Collectible",


### PR DESCRIPTION
Frigri Wine cellar now has a customMessage for its teleporter, since it places you in Frigri itself.
Crystal of Earth now references the Earth Plane, not Earth Plains.