### PR TITLE
Update Merchant's Guild.json

### DIFF
--- a/world-maps/world/Merchant's Guild.json
+++ b/world-maps/world/Merchant's Guild.json
@@ -4150,7 +4150,7 @@
                 {
                  "height":192,
                  "id":123,
-                 "name":"Raburro Merchant's Hall",
+                 "name":"Homlet Merchant's Hall",
                  "properties":
                     {
 


### PR DESCRIPTION
Fixed a Merchant's Guild region that was named after the wrong town. Thanks again, @AscendedGravity. #63 