### PR TITLE
Update Odd Amulet Rarity

### DIFF
--- a/world-maps/world/Norkos.json
+++ b/world-maps/world/Norkos.json
@@ -2457,7 +2457,7 @@
                  "properties":
                     {
                      "flavorText":"Looking into the amulet's gem fills you with a strong sense of dread.",
-                     "rarity":"pro",
+                     "rarity":"godly",
                      "storyline":"Lore: Lich Brothers"
                     },
                  "propertytypes":


### PR DESCRIPTION
Thanks to Krondor for pointing out the Odd Amulet's rarity was incorrect. It's not used for any skills/spells, but does unlock a door.