### PR TITLE
Fix Astral Plane Teleport, update HoH

### DIFF
--- a/world-maps/dungeons/astralplane/The Astral Plane.json
+++ b/world-maps/dungeons/astralplane/The Astral Plane.json
@@ -1116,7 +1116,8 @@
                      "desty":"48",
                      "fromName":"The Astral Plane",
                      "map":"Merchant's Guild",
-                     "movementType":"teleport"
+                     "movementType":"teleport",
+                     "requireCollectible":"Astral Tuning Fork"
                     },
                  "propertytypes":
                     {
@@ -1124,7 +1125,8 @@
                      "desty":"string",
                      "fromName":"string",
                      "map":"string",
-                     "movementType":"string"
+                     "movementType":"string",
+                     "requireCollectible":"string"
                     },
                  "rotation":0,
                  "type":"Teleport",

--- a/world-maps/world/Hall of Heroes.json
+++ b/world-maps/world/Hall of Heroes.json
@@ -1830,6 +1830,18 @@
                  "width":16,
                  "x":192,
                  "y":208
+                }, 
+                {
+                 "gid":15,
+                 "height":16,
+                 "id":130,
+                 "name":"Sviseerd",
+                 "rotation":0,
+                 "type":"Hero (Donator)",
+                 "visible":true,
+                 "width":16,
+                 "x":192,
+                 "y":240
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1905,7 +1917,7 @@
          "x":0,
          "y":0
         }],
- "nextobjectid":130,
+ "nextobjectid":131,
  "orientation":"orthogonal",
  "properties":
     {


### PR DESCRIPTION
Require the Astral Tuning Fork to get into the Merchant's Guild on the Astral Plane.

Add Sviseerd to HoH.