### PR TITLE
Gambling table test

### DIFF
--- a/world-maps/world/Norkos Secret -1.json
+++ b/world-maps/world/Norkos Secret -1.json
@@ -176,6 +176,26 @@
                  "width":16,
                  "x":192,
                  "y":80
+                }, 
+                {
+                 "gid":85,
+                 "height":16,
+                 "id":12,
+                 "name":"",
+                 "properties":
+                    {
+                     "forceEvent":"Enchant"
+                    },
+                 "propertytypes":
+                    {
+                     "forceEvent":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":96,
+                 "y":80
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -184,7 +204,7 @@
          "x":0,
          "y":0
         }],
- "nextobjectid":12,
+ "nextobjectid":13,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tileheight":16,

--- a/world-maps/world/Norkos Secret -1.json
+++ b/world-maps/world/Norkos Secret -1.json
@@ -134,7 +134,7 @@
                  "type":"",
                  "visible":true,
                  "width":16,
-                 "x":96,
+                 "x":128,
                  "y":80
                 }, 
                 {
@@ -154,6 +154,26 @@
                  "type":"",
                  "visible":true,
                  "width":16,
+                 "x":160,
+                 "y":80
+                }, 
+                {
+                 "gid":149,
+                 "height":16,
+                 "id":11,
+                 "name":"Gambling Table",
+                 "properties":
+                    {
+                     "forceEvent":"Gambling"
+                    },
+                 "propertytypes":
+                    {
+                     "forceEvent":"string"
+                    },
+                 "rotation":0,
+                 "type":"For Gambling Test",
+                 "visible":true,
+                 "width":16,
                  "x":192,
                  "y":80
                 }],
@@ -164,7 +184,7 @@
          "x":0,
          "y":0
         }],
- "nextobjectid":11,
+ "nextobjectid":12,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tileheight":16,


### PR DESCRIPTION
Moved around the existing test tables, add an additional test table with filled in properties, and add an enchant altar to verify map updates  (and see if the gambling tables fail to load again.)